### PR TITLE
Add empty line in ASN column for empty ASNs

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,8 @@
                                     }
                                     companyCounter++;
                                 }
+                            } else {
+                                asnStr.append('<br />');
                             }
                         } else {
                             companyStr.append(user.companies[comp] + '<br />');


### PR DESCRIPTION
When a company doesn't have an ASN defined, the ASNs of the companies below it would be placed behind the company without an ASN, thus causing confusion. This patch fixes that confusion.